### PR TITLE
Upgrade lodash, require specific lodash methods

### DIFF
--- a/lib/getPluginOptsFromBabelOpts.js
+++ b/lib/getPluginOptsFromBabelOpts.js
@@ -1,14 +1,16 @@
-var _ = require('lodash');
+var find = require('lodash/find');
+var isArray = require('lodash/isArray');
+var isObject = require('lodash/isObject');
 
 // Sadly this is the only way to get a plugin's options from within `manipulateOptions`...
 // In `pre()`, they can be accessed by `this.opts`, but unfortunately `manipulateOptions` gets
 // called *before* `pre()` and isn't supplied with `this`
 module.exports = function getPluginOptsFromBabelOpts(babelOpts) {
-  var plugin = _.find(babelOpts.plugins, function (plugin) {
+  var plugin = find(babelOpts.plugins, function (plugin) {
     // hack: assume it's the correct plugin if it's options have a `resolveDirs` property
-    return _.isArray(plugin) &&
-      _.isObject(plugin[1]) &&
-      _.isArray(plugin[1].resolveDirs);
+    return isArray(plugin) &&
+      isObject(plugin[1]) &&
+      isArray(plugin[1].resolveDirs);
   });
 
   if (!plugin) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/jshanson7/babel-plugin-resolver#readme",
   "dependencies": {
     "babel-resolver": "^0.0.18",
-    "lodash": "^3.10.1"
+    "lodash": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",


### PR DESCRIPTION
Test passes, lodash method signatures for these methods hasn't changed from v3 to v4.
