### PR TITLE
Check if file exists before searching its path

### DIFF
--- a/lib/ResolverPlugin.js
+++ b/lib/ResolverPlugin.js
@@ -1,6 +1,7 @@
 var resolve = require('path').resolve;
 var createBabelResolver = require('babel-resolver');
 var findNodeModulesPaths = require('babel-resolver/lib/findNodeModulesPaths');
+var getFilenameFromBabelOpts = require('./getFilenameFromBabelOpts');
 var getPluginOptsFromBabelOpts = require('./getPluginOptsFromBabelOpts');
 var getAbsoluteDirsFromInputDirs = require('./getAbsoluteDirsFromInputDirs');
 
@@ -9,8 +10,11 @@ module.exports = function ResolverPlugin() {
   return {
     manipulateOptions: function (babelOpts) {
       if (!resolver) {
+        var filename = getFilenameFromBabelOpts(babelOpts);
+        if (!filename) { return; }
+
         var pluginOpts = getPluginOptsFromBabelOpts(babelOpts);
-        var nodeModulesPaths = findNodeModulesPaths(babelOpts.filename);
+        var nodeModulesPaths = findNodeModulesPaths(filename);
         var appRootPath = resolve(nodeModulesPaths[0], '..');
         var absoluteDirs = getAbsoluteDirsFromInputDirs(pluginOpts.resolveDirs, appRootPath);
         resolver = createBabelResolver.apply(null, absoluteDirs);

--- a/lib/ResolverPlugin.js
+++ b/lib/ResolverPlugin.js
@@ -11,7 +11,7 @@ module.exports = function ResolverPlugin() {
     manipulateOptions: function (babelOpts) {
       if (!resolver) {
         var filename = getFilenameFromBabelOpts(babelOpts);
-        if (!filename) { return; }
+        if (!filename) { return null; }
 
         var pluginOpts = getPluginOptsFromBabelOpts(babelOpts);
         var nodeModulesPaths = findNodeModulesPaths(filename);

--- a/lib/getFilenameFromBabelOpts.js
+++ b/lib/getFilenameFromBabelOpts.js
@@ -5,8 +5,8 @@ module.exports = function getFilenameFromBabelOpts(babelOpts) {
     fs.lstatSync(babelOpts.filename);
   } catch (e) {
     // File doesn't exist
-    return;
+    return null;
   }
 
-  return(babelOpts.filename);
+  return babelOpts.filename;
 };

--- a/lib/getFilenameFromBabelOpts.js
+++ b/lib/getFilenameFromBabelOpts.js
@@ -1,0 +1,12 @@
+var fs = require('fs');
+
+module.exports = function getFilenameFromBabelOpts(babelOpts) {
+  try {
+    fs.lstatSync(babelOpts.filename);
+  } catch (e) {
+    // File doesn't exist
+    return;
+  }
+
+  return(babelOpts.filename);
+};


### PR DESCRIPTION
`babelOpts.filename` might not always be a valid file, ex it's set to `'repl'` in `babel-node`

This might fix #2
